### PR TITLE
Calling stopLoading()  redirected back to the app in Android.

### DIFF
--- a/src/tns-oauth-login-webview-controller.ts
+++ b/src/tns-oauth-login-webview-controller.ts
@@ -130,6 +130,9 @@ export class TnsOAuthLoginWebViewController
         this.loginController.client.provider.options.redirectUri
       )
     ) {
+      if (isAndroid && args.object && args.object.stopLoading) {
+        args.object.stopLoading();
+      }
       this.resumeWithUrl(args.url);
     }
   }


### PR DESCRIPTION
When redirecting to an intent on android the WebView will briefly show a broken link on android before redirecting back to the the main app.  this is a known limitation where you cannot open intents in android's web view.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

